### PR TITLE
Added selfClose option

### DIFF
--- a/lib/ebml/encoder.js
+++ b/lib/ebml/encoder.js
@@ -113,7 +113,12 @@ EbmlEncoder.prototype.startTag = function(tagName, info) {
     if (this._stack.length > 0) {
         this._stack[this._stack.length - 1].children.push(tag);
     }
-    this._stack.push(tag);
+    
+    if(info.selfClose && info.end === -1) {
+        this.writeTag(tagName, info.data);
+    } else {
+        this._stack.push(tag);
+    }
 };
 
 EbmlEncoder.prototype.endTag = function() {


### PR DESCRIPTION
Allows streaming `Segment`s by setting the length to unknown. Only use this when opening a top-level element, not sure what will happen if you do it nested.